### PR TITLE
Döljer månadsväljaren

### DIFF
--- a/default.css
+++ b/default.css
@@ -251,3 +251,9 @@ div.ms-acal-item, div.ms-acal-item * {
     background-color: lightgray;
     color: black !important;
 }
+
+
+/* Hide Datepicker and associated items in left menu */
+div#DatePickerDiv, div.ms-acal-apanel-outer {
+    display: none !important;
+}


### PR DESCRIPTION
Eftersom den var riktigt jobbig att styla snyggt.
Det går tillräckligt(?) snabbt att bläddra med pilarna ovanför kalendern
![screen shot 2015-06-17 at 14 10 13](https://cloud.githubusercontent.com/assets/1773878/8206706/3551b45e-14fc-11e5-8a5b-2be0301ec66c.png)

Avser #13 